### PR TITLE
Auto-center Global Relationship Graph on Current Note (Reviewer/Editor/Browser)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -168,6 +168,12 @@ class AnkiNoteLinker(object):
                             {json.dumps(childJsNodes, default=lambda o: o.__dict__)}
                         )'''
             )
+            # If the global graph window is open, center it on the current note.
+            try:
+                if state.globalGraph is not None:
+                    state.globalGraph.centerOnNote(card.note().id)
+            except Exception:
+                pass
 
     def injectLinksPageToMainWindow(self):
         mw.reviewer.linksPageSplitter = QSplitter()
@@ -554,6 +560,12 @@ class AnkiNoteLinker(object):
                 {json.dumps(adaptScale)}
                 )'''
             )
+            # Also tell the global graph (if open) to focus this note.
+            try:
+                if state.globalGraph is not None:
+                    state.globalGraph.centerOnNote(currentId)
+            except Exception:
+                pass
 
     def appendJsToEditor(self, web_content, context):
         """Enable the editor to support shortcut keys and double-click nid trigger operations"""


### PR DESCRIPTION
Adds automatic centering in the Global Relationship Graph: when a note/card is shown in the reviewer, editor, or browser, an open global graph will animate to center that note (if present). The Python side invokes a small JS snippet in the webview to locate the node and use the existing resetCenterAnimation for smooth panning, retrying briefly if layout isn’t ready. No HTML/JS templates were modified; calls are safe no-ops if the graph is closed or the node isn’t in the current graph.